### PR TITLE
Fixed OpenGL error 1282 on Linux Mesa driver

### DIFF
--- a/GameEngine/src/graphics/window.cpp
+++ b/GameEngine/src/graphics/window.cpp
@@ -37,6 +37,10 @@ namespace GameEngine {
 				std::cout << "Error initializing GLFW" << std::endl;
 				return false;
 			}
+			
+			glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+			glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+			glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
 
 			window = glfwCreateWindow(width, height, name, NULL, NULL);
 			if (!window) {


### PR DESCRIPTION
Fix was made by explicitly requesting OpenGL 3.3 Core using glfwWindowHint. The Mesa OpenGL implementation provides only a 3.0 compatibility context by default unless a higher version is explicitly requested.